### PR TITLE
Homepage Sorting

### DIFF
--- a/themes/hugo_theme_robust/layouts/index.html
+++ b/themes/hugo_theme_robust/layouts/index.html
@@ -5,8 +5,8 @@
 
       <div class="articles">
         <div class="row">
-          {{ range $key, $value := .Paginator.Pages}}
-          <div class="col-sm-{{ if lt $key 4 }}6{{ else }}4{{ end }}">
+          {{ range where .Data.Pages "Section" "post"}}
+          <div class="col-sm-6">
             {{ .Render "li" }}
           </div>
           {{ end }}


### PR DESCRIPTION
Specifies that only pages within the “post” folder will be shown.